### PR TITLE
Ajouter support de "storage_type" et corriger typo

### DIFF
--- a/src/BFGS/Type.jl
+++ b/src/BFGS/Type.jl
@@ -15,7 +15,7 @@ function BFGSData(
     scaling :: Bool = true ) where {T}
 
     n,  = size(M₀) # add checks for square symmetric matrix
-    
+
     BFGSData{T}(M₀, scaling, Vector{T}(undef, n))
 end
 
@@ -60,16 +60,17 @@ BFGSOperator{T}(
     0,
 )
 
-import LinearOperators:has_args5, use_prod5!, isallocated5
+import LinearOperators:has_args5, use_prod5!, isallocated5, storage_type
 has_args5(op::BFGSOperator) = true
 use_prod5!(op::BFGSOperator) = true
 isallocated5(op::BFGSOperator) = true
+storage_type(op::BFGSOperator{T}) where {T} = Vector{T}
 
 
 """
     InverseBFGSOperator(M₀, n [; scaling=true])
     InverseBFGSOperator(n, [; scaling=true])
-Construct a BFGS approximation in inverse form. 
+Construct a BFGS approximation in inverse form.
 """
 function InverseBFGSOperator(M :: Matrix{T}, n :: Int; kwargs...) where {T <: Real}
     kwargs = Dict(kwargs)
@@ -94,7 +95,7 @@ function InverseBFGSOperator(M :: Matrix{T}, n :: Int; kwargs...) where {T <: Re
 
         return res
     end
-    
+
     prod! = @closure (res, x, α, β) -> bfgs_multiply(res, bfgs_data, x, α, β)
     return BFGSOperator{T}(n, n, true, true, prod!, prod!, prod!, bfgs_data)
 end

--- a/src/BFGS/TypeChol.jl
+++ b/src/BFGS/TypeChol.jl
@@ -14,7 +14,7 @@ function ChBFGSData(
 
     n,  = size(M₀) # add checks for square symmetric matrix ≻ 0
     C₀ = cholesky(M₀)
-    
+
     ChBFGSData{T}(C₀, scaling, Vector{T}(undef, n))
 end
 
@@ -59,17 +59,18 @@ ChBFGSOperator{T}(
     0,
 )
 
-import LinearOperators:has_args5, use_prod5!, isallocated5
+import LinearOperators:has_args5, use_prod5!, isallocated5, storage_type
 has_args5(op::ChBFGSOperator) = true
 use_prod5!(op::ChBFGSOperator) = true
 isallocated5(op::ChBFGSOperator) = true
+storage_type(op::ChBFGSOperator{T}) where {T} = Vector{T}
 
 
 
 """
     InverseBFGSOperator(M₀, n [; scaling=true])
     InverseBFGSOperator(n, [; scaling=true])
-Construct a BFGS approximation in inverse form. 
+Construct a BFGS approximation in inverse form.
 """
 function ChBFGSOperator(M :: Matrix{T}, n :: Int; kwargs...) where {T <: Real}
     kwargs = Dict(kwargs)
@@ -95,7 +96,7 @@ function ChBFGSOperator(M :: Matrix{T}, n :: Int; kwargs...) where {T <: Real}
 
         return res
     end
-    
+
     prod! = @closure (res, x, α, β) -> Chbfgs_multiply(res, Ch_bfgs_data, x, α, β)
     return ChBFGSOperator{T}(n, n, true, true, prod!, prod!, prod!, Ch_bfgs_data)
 end

--- a/src/BFGS/TypeCompact.jl
+++ b/src/BFGS/TypeCompact.jl
@@ -1,7 +1,6 @@
 export CompactInverseBFGSOperator
 
 import Base.push!
-import LinearOperators: has_args5, use_prod5!, isallocated5
 
 using FastClosures
 using LinearAlgebra
@@ -80,9 +79,11 @@ CompactInverseBFGSOperator{T}(
     0,
 )
 
+import LinearOperators: has_args5, use_prod5!, isallocated5
 has_args5(op::CompactInverseBFGSOperator) = true
 use_prod5!(op::CompactInverseBFGSOperator) = true
 isallocated5(op::CompactInverseBFGSOperator) = true
+storage_type(op::CompactInverseBFGSOperator{T}) where {T} = Vector{T}
 
 """
         CompactInverseBFGSOperator(T, n, [mem=5])

--- a/src/BFGS/bfgsStopLS.jl
+++ b/src/BFGS/bfgsStopLS.jl
@@ -1,4 +1,4 @@
-export bfgs_StopLS, L_bfgs_StopLS, M_bfgs_StopLS, Ch_bfgs_StopLS, C_bfgs_Stop
+export bfgs_StopLS, L_bfgs_StopLS, M_bfgs_StopLS, Ch_bfgs_StopLS, C_bfgs_StopLS
 
 include("AcceptAll.jl")
 


### PR DESCRIPTION
Lancer "test LSDescent" avec la version la plus récente des LInearOperators ne fonctionnent pas sans ce fix. 

J'ai aussi corrigé un typo dans bfgs_StopLS sans quoi rouler des tests avec C_bfgs_StopLS ne fonctionnait pas. 